### PR TITLE
Add in python-memcached dependency to bootstrap.py

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -33,7 +33,7 @@ def install_deps():
             'xapian-bindings-python', 'diffstat', 'fedpkg', 'svn', 'wget',
             'python-xappy', 'python-webob', 'moksha', 'TurboGears2',
             'python-dogpile-cache', 'python-dogpile-core',
-            'python-retask',
+            'python-retask', 'python-memcached',
         ]
         run('sudo yum install -q -y --enablerepo=updates-testing ' + ' '.join(reqs))
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         "TurboGears2",
         "dogpile.cache",
         "retask",
+        "python-memcached",
         #"PyOpenSSL",
         #"SQLAlchemy>=0.5",
         #"xappy",


### PR DESCRIPTION
This might be totally the wrong way to do this so please let me know if there's another way to solve this problem. I was getting the following error until I installed python-memcached.

```
/home/dadavis/Projects/fedora-packages/fedoracommunity/connectors/api/utils.py:163: SyntaxWarning: assertion is always true, perhaps remove parentheses?
  assert(isinstance(cast, type),
/home/dadavis/Projects/fedora-packages/fedoracommunity/connectors/api/utils.py:175: SyntaxWarning: assertion is always true, perhaps remove parentheses?
  assert(not(a in self._translation_table),
Traceback (most recent call last):
  File "/bin/paster", line 9, in <module>
    load_entry_point('PasteScript==1.7.5', 'console_scripts', 'paster')()
  File "/usr/lib/python2.7/site-packages/paste/script/command.py", line 104, in run
    invoke(command, command_name, options, args[1:])
  File "/usr/lib/python2.7/site-packages/paste/script/command.py", line 143, in invoke
    exit_code = runner.run(args)
  File "/usr/lib/python2.7/site-packages/paste/script/command.py", line 238, in run
    result = self.command()
  File "/usr/lib/python2.7/site-packages/paste/script/serve.py", line 284, in command
    relative_to=base, global_conf=vars)
  File "/usr/lib/python2.7/site-packages/paste/script/serve.py", line 321, in loadapp
    **kw)
  File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 247, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 272, in loadobj
    return context.create()
  File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 710, in create
    return self.object_type.invoke(self)
  File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 146, in invoke
    return fix_call(context.object, context.global_conf, **context.local_conf)
  File "/usr/lib/python2.7/site-packages/paste/deploy/util.py", line 56, in fix_call
    val = callable(*args, **kw)
  File "/home/dadavis/Projects/fedora-packages/fedoracommunity/config/middleware.py", line 43, in make_app
    **app_conf)
  File "/usr/lib/python2.7/site-packages/tg/configuration.py", line 916, in make_base_app
    app = wrap_app(app)
  File "/home/dadavis/Projects/fedora-packages/fedoracommunity/config/middleware.py", line 36, in make_middleware
    app = FCommConnectorMiddleware(app)
  File "/home/dadavis/Projects/fedora-packages/fedoracommunity/connectors/api/mw.py", line 59, in __init__
    self.load_connectors()
  File "/home/dadavis/Projects/fedora-packages/fedoracommunity/connectors/api/mw.py", line 248, in load_connectors
    conn_class.register()
  File "/home/dadavis/Projects/fedora-packages/fedoracommunity/connectors/wikiconnector.py", line 49, in register
    cls.register_query_most_active_pages()
  File "/home/dadavis/Projects/fedora-packages/fedoracommunity/connectors/wikiconnector.py", line 59, in register_query_most_active_pages
    can_paginate = True)
  File "/home/dadavis/Projects/fedora-packages/fedoracommunity/connectors/api/connector.py", line 426, in register_query
    if cls._cache():
  File "/home/dadavis/Projects/fedora-packages/fedoracommunity/connectors/api/connector.py", line 132, in _cache
    cls.__cache.configure_from_config(config, 'cache.connectors.')
  File "/usr/lib/python2.7/site-packages/dogpile/cache/region.py", line 271, in configure_from_config
    _config_prefix="%sarguments." % prefix
  File "/usr/lib/python2.7/site-packages/dogpile/cache/region.py", line 187, in configure
    _config_prefix
  File "/usr/lib/python2.7/site-packages/dogpile/cache/api.py", line 79, in from_config_dict
    for key in config_dict
  File "/usr/lib/python2.7/site-packages/dogpile/cache/backends/memcached.py", line 176, in __init__
    super(MemcacheArgs, self).__init__(arguments)
  File "/usr/lib/python2.7/site-packages/dogpile/cache/backends/memcached.py", line 99, in __init__
    self._imports()
  File "/usr/lib/python2.7/site-packages/dogpile/cache/backends/memcached.py", line 247, in _imports
    import memcache
ImportError: No module named memcache
```
