### PR TITLE
key ops and end-tag

### DIFF
--- a/fedoracommunity/connectors/yumconnector.py
+++ b/fedoracommunity/connectors/yumconnector.py
@@ -160,7 +160,9 @@ class YumConnector(IConnector, ICall, ISearch, IQuery):
 
         return pkg
 
-    def _pkgtuples_to_rows(self, pkgtuples, _eq='=', _gt='>', _lt='<', _ge='>=', _le='<=', find_provided_by=False):
+    def _pkgtuples_to_rows(self, pkgtuples, _eq='\\u003D', _gt='\\u003E',
+                           _lt='\\u003C', _ge='\\u003E\\u003D',
+                           _le='\\u003C\\u003D', find_provided_by=False):
         rows = []
 
         for pkg in pkgtuples:


### PR DESCRIPTION
fix issue with HTMLParser.py#l48
when ops ends with a sign "u'ops': u'<'}"

this pull request is a possible solution to this issue https://github.com/fedora-infra/fedora-packages/issues/28

required: https://github.com/fedora-infra/pkgwat.api/pull/14
