### PR TITLE
make the bz cookiefile location configurable.

### DIFF
--- a/fedoracommunity/connectors/bugzillaconnector.py
+++ b/fedoracommunity/connectors/bugzillaconnector.py
@@ -65,7 +65,7 @@ class BugzillaConnector(IConnector, ICall, IQuery):
 
     @property
     def _bugzilla(self):
-        return Bugzilla(url=self._base_url)
+        return Bugzilla(url=self._base_url, cookiefile=self._cookiefile)
 
     # IConnector
     @classmethod
@@ -73,6 +73,9 @@ class BugzillaConnector(IConnector, ICall, IQuery):
         cls._base_url = config.get(
             'fedoracommunity.connector.bugzilla.baseurl',
             'https://bugzilla.redhat.com/xmlrpc.cgi')
+        cls._cookiefile = config.get(
+            'fedoracommunity.connector.bugzilla.cookiefile',
+            -1)
 
         cls.register_query_bugs()
 


### PR DESCRIPTION
By default (with a value of `-1`) the latest python-bugzilla tries to write a cookiefile in `/var/www/.bugzillacookies`.  We'd rather write it somewhere else in production.. like in `/var/cache/fedoracommunity/bugzillacookies`.
