### PR TITLE
Add a configurable timestamp to this tool.

### DIFF
--- a/bin/fcomm-index-latest-builds
+++ b/bin/fcomm-index-latest-builds
@@ -27,6 +27,9 @@ if __name__ == "__main__":
                       default='update',
                       help="what action to perform.  Either 'init' or 'update'",
                       metavar="ACTION")
+    parser.add_option("--timestamp", dest="timestamp",
+                      default=None,
+                      help="how far back to run the query.")
 
     (options, args) = parser.parse_args()
     lockfile = LockFile(
@@ -38,10 +41,14 @@ if __name__ == "__main__":
         print "Error acquiring lock file: %s" % str(e)
         exit(-1)
 
+    # None or an int
+    timestamp = options.timestamp and int(options.timestamp)
+
     try:
         run(
             cache_path=options.cache_path,
             action=options.action,
+            timestamp=timestamp,
             koji_url=options.koji_url)
     finally:
         lockfile.release()


### PR DESCRIPTION
This is for #77 so I can force the indexer to go back in time and pick
up 'marble' (which it somehow missed).
