### PR TITLE
Remove the relationships tab from the UI.

### DIFF
--- a/fedoracommunity/widgets/package/package.py
+++ b/fedoracommunity/widgets/package/package.py
@@ -67,8 +67,8 @@ class PackageNavWidget(TabWidget):
                         ('Bugs', 'package_bugs'),
                         ('Contents', 'package_contents'),
                         ('Changelog', 'package_changelog'),
-                        ('Sources', 'package_sources'),
-                        ('Relationships', 'package_relationships')])
+                        ('Sources', 'package_sources')])
+                        #('Relationships', 'package_relationships')])
     base_url = Template(text='/${kwds["package_name"]}/');
     default_tab = 'Overview'
     args = twc.Param(default=None)


### PR DESCRIPTION
All good things must come to an end.  The relationships tab is consistently
broken due to yum behaving poorly in a threaded context.

We'll try to revive it some day when we're on rhel7 with dnf.  (That will
require a rewrite of the YumConnector as a DnfConnector).
