### PR TITLE
Wrap "LATEST BUILD" field.

### DIFF
--- a/fedoracommunity/public/css/application-chrome.css
+++ b/fedoracommunity/public/css/application-chrome.css
@@ -1650,6 +1650,7 @@ em.note {
 
 #package-info-bar .build div {
   font-size: 11pt;
+  word-wrap: break-word;
 }
 
 #package-info-bar .package-owner {


### PR DESCRIPTION
I found that with long package version-release strings, the "LATEST BUILD" field would bleed into the package description, such as what you see https://apps.fedoraproject.org/packages/xu4/overview/

Here's a one-liner.  Hope I did this correctly.