### PR TITLE
Fix bugzilla + tw2.

### DIFF
--- a/fedoracommunity/widgets/package/bugs.py
+++ b/fedoracommunity/widgets/package/bugs.py
@@ -12,7 +12,6 @@ class BugStatsWidget(twc.Widget):
     product = twc.Param(default='Fedora')
     version = twc.Param(default='rawhide')
     epel_version = twc.Param(default='el6')
-    package = twc.Param(default=None)
     num_open = twc.Param(default='-')
     num_new_this_week = twc.Param(default='')
     num_closed_this_week = twc.Param(default='')
@@ -54,7 +53,6 @@ class BugsGrid(Grid):
     resource = 'bugzilla'
     resource_path = 'query_bugs'
     release_table = twc.Param()
-    package = twc.Param()
     template = "mako:fedoracommunity.widgets.package.templates.bugs_table_widget"
 
     def prepare(self):
@@ -94,7 +92,6 @@ class BugsWidget(twc.Widget):
     bug_stats = BugStatsWidget
     bug_grid = BugsGrid
     kwds = twc.Param()
-    package = twc.Param()
     template = "mako:fedoracommunity.widgets.package.templates.bugs"
 
     def prepare(self):


### PR DESCRIPTION
An update to tw2.core upstream was causing problems with the 'bugs' tab
in development.  Basically, the semantics of tw2.core.Param() became
more restrictive, meaning that the package name would have to be passed
in as an explicit keyword argument.  fedora-packages doesn't do that, so
the BugsWidget was failing with a traceback from tw2's validation code.
However, the BugsWidget was the *only* package widget from
fedora-packages that had this Param declared.. so I'm just removing it
to put it in line with all the other widgets.. and to get everything
working again.