### PR TITLE
Use HTTPS where possible

### DIFF
--- a/fedoracommunity/public/pages/tour/index.html
+++ b/fedoracommunity/public/pages/tour/index.html
@@ -262,15 +262,15 @@ Find out!
                     The Fedora Project is maintained and driven by the community and sponsored by Red Hat.  This is a community maintained site.  Red Hat is not responsible for content.
                 </p>
                 <ul>
-                    <li class="first"><a href="http://fedoraproject.org/en/sponsors">Sponsors</a></li>
-                    <li><a href="http://fedoraproject.org/wiki/Legal">Legal</a></li>
-                    <li><a href="http://fedoraproject.org/wiki/Legal/TrademarkGuidelines">Trademark Guidelines</a></li>
-                    <li><a href="http://fedoracommunity.fedorahosted.org">Get the source for Fedora Community</a></li>
+                    <li class="first"><a href="https://fedoraproject.org/en/sponsors">Sponsors</a></li>
+                    <li><a href="https://fedoraproject.org/wiki/Legal">Legal</a></li>
+                    <li><a href="https://fedoraproject.org/wiki/Legal/TrademarkGuidelines">Trademark Guidelines</a></li>
+                    <li><a href="https://fedoracommunity.fedorahosted.org">Get the source for Fedora Community</a></li>
 
-                    <li><a href="http://moksha.fedorahosted.org">Get the source for Moksha</a></li>
+                    <li><a href="https://moksha.fedorahosted.org">Get the source for Moksha</a></li>
                 </ul>
                 <br />
-                <a href="http://moksha.fedorahosted.org"><img src="../../images/Powered-by-moksha_button.png"/></a>
+                <a href="https://moksha.fedorahosted.org"><img src="../../images/Powered-by-moksha_button.png"/></a>
             </div>
         </div>
 

--- a/fedoracommunity/public/pages/tour/packages.html
+++ b/fedoracommunity/public/pages/tour/packages.html
@@ -432,15 +432,15 @@ make package maintenance easier!
                     The Fedora Project is maintained and driven by the community and sponsored by Red Hat.  This is a community maintained site.  Red Hat is not responsible for content.
                 </p>
                 <ul>
-                    <li class="first"><a href="http://fedoraproject.org/en/sponsors">Sponsors</a></li>
-                    <li><a href="http://fedoraproject.org/wiki/Legal">Legal</a></li>
-                    <li><a href="http://fedoraproject.org/wiki/Legal/TrademarkGuidelines">Trademark Guidelines</a></li>
-                    <li><a href="http://fedoracommunity.fedorahosted.org">Get the source for Fedora Community</a></li>
+                    <li class="first"><a href="https://fedoraproject.org/en/sponsors">Sponsors</a></li>
+                    <li><a href="https://fedoraproject.org/wiki/Legal">Legal</a></li>
+                    <li><a href="https://fedoraproject.org/wiki/Legal/TrademarkGuidelines">Trademark Guidelines</a></li>
+                    <li><a href="https://fedoracommunity.fedorahosted.org">Get the source for Fedora Community</a></li>
 
-                    <li><a href="http://moksha.fedorahosted.org">Get the source for Moksha</a></li>
+                    <li><a href="https://moksha.fedorahosted.org">Get the source for Moksha</a></li>
                 </ul>
                 <br />
-                <a href="http://moksha.fedorahosted.org"><img src="../../images/Powered-by-moksha_button.png"/></a>
+                <a href="https://moksha.fedorahosted.org"><img src="../../images/Powered-by-moksha_button.png"/></a>
             </div>
         </div>
 

--- a/fedoracommunity/public/pages/tour/people.html
+++ b/fedoracommunity/public/pages/tour/people.html
@@ -368,15 +368,15 @@ moksha_profile = false;
                     The Fedora Project is maintained and driven by the community and sponsored by Red Hat.  This is a community maintained site.  Red Hat is not responsible for content.
                 </p>
                 <ul>
-                    <li class="first"><a href="http://fedoraproject.org/en/sponsors">Sponsors</a></li>
-                    <li><a href="http://fedoraproject.org/wiki/Legal">Legal</a></li>
-                    <li><a href="http://fedoraproject.org/wiki/Legal/TrademarkGuidelines" moksha_url="static">Trademark Guidelines</a></li>
-                    <li><a href="http://fedoracommunity.fedorahosted.org" moksha_url="static">Get the source for Fedora Community</a></li>
+                    <li class="first"><a href="https://fedoraproject.org/en/sponsors">Sponsors</a></li>
+                    <li><a href="https://fedoraproject.org/wiki/Legal">Legal</a></li>
+                    <li><a href="https://fedoraproject.org/wiki/Legal/TrademarkGuidelines" moksha_url="static">Trademark Guidelines</a></li>
+                    <li><a href="https://fedoracommunity.fedorahosted.org" moksha_url="static">Get the source for Fedora Community</a></li>
 
-                    <li><a href="http://moksha.fedorahosted.org">Get the source for Moksha</a></li>
+                    <li><a href="https://moksha.fedorahosted.org">Get the source for Moksha</a></li>
                 </ul>
                 <br />
-                <a href="http://moksha.fedorahosted.org"><img src="../../images/Powered-by-moksha_button.png"/></a>
+                <a href="https://moksha.fedorahosted.org"><img src="../../images/Powered-by-moksha_button.png"/></a>
             </div>
         </div>
 

--- a/fedoracommunity/public/pages/tour/search.html
+++ b/fedoracommunity/public/pages/tour/search.html
@@ -220,15 +220,15 @@ Search across all of the packages that are part of Fedora and all of the communi
                     The Fedora Project is maintained and driven by the community and sponsored by Red Hat.  This is a community maintained site.  Red Hat is not responsible for content.
                 </p>
                 <ul>
-                    <li class="first"><a href="http://fedoraproject.org/en/sponsors">Sponsors</a></li>
-                    <li><a href="http://fedoraproject.org/wiki/Legal">Legal</a></li>
-                    <li><a href="http://fedoraproject.org/wiki/Legal/TrademarkGuidelines">Trademark Guidelines</a></li>
-                    <li><a href="http://fedoracommunity.fedorahosted.org">Get the source for Fedora Community</a></li>
+                    <li class="first"><a href="https://fedoraproject.org/en/sponsors">Sponsors</a></li>
+                    <li><a href="https://fedoraproject.org/wiki/Legal">Legal</a></li>
+                    <li><a href="https://fedoraproject.org/wiki/Legal/TrademarkGuidelines">Trademark Guidelines</a></li>
+                    <li><a href="https://fedoracommunity.fedorahosted.org">Get the source for Fedora Community</a></li>
 
-                    <li><a href="http://moksha.fedorahosted.org">Get the source for Moksha</a></li>
+                    <li><a href="https://moksha.fedorahosted.org">Get the source for Moksha</a></li>
                 </ul>
                 <br />
-                <a href="http://moksha.fedorahosted.org"><img src="../../images/Powered-by-moksha_button.png"/></a>
+                <a href="https://moksha.fedorahosted.org"><img src="../../images/Powered-by-moksha_button.png"/></a>
             </div>
         </div>
 

--- a/fedoracommunity/templates/footer.mak
+++ b/fedoracommunity/templates/footer.mak
@@ -5,14 +5,14 @@
             <p>Found a bug?  <a href="https://github.com/fedora-infra/fedora-packages/issues/new">File a ticket.</a>    Note:  There's some caching going on here.  If you expect something and don't see it, check back in 5 minutes.</p>
             This Web Site is licensed under the GNU Affero General Public License.  You may get sources for the current running code from these repositories:
             <ul>
-                <li><a href="http://fedoraproject.org/wiki/Legal/TrademarkGuidelines">Trademark Guidelines</a></li>
+                <li><a href="https://fedoraproject.org/wiki/Legal/TrademarkGuidelines">Trademark Guidelines</a></li>
                 <li><a href="https://github.com/fedora-infra/fedora-packages">Get the source for Fedora Packages</a></li>
-                <li><a href="http://fedorahosted.org/moksha">Get the source for Moksha</a></li>
+                <li><a href="https://fedorahosted.org/moksha">Get the source for Moksha</a></li>
 
-                <li><a href="http://infrastructure.fedoraproject.org/testing/5/SRPMS/">RHEL5 Testing SRPMS</a></li>
-                <li><a href="http://infrastructure.fedoraproject.org/testing/6/SRPMS/">RHEL6 Testing SRPMS</a></li>
-                <li><a href="http://infrastructure.fedoraproject.org/5/SRPMS/">RHEL5 Production SRPMS</a></li>
-                <li><a href="http://infrastructure.fedoraproject.org/6/SRPMS/">RHEL6 Production SRPMS</a></li>
+                <li><a href="https://infrastructure.fedoraproject.org/testing/5/SRPMS/">RHEL5 Testing SRPMS</a></li>
+                <li><a href="https://infrastructure.fedoraproject.org/testing/6/SRPMS/">RHEL6 Testing SRPMS</a></li>
+                <li><a href="https://infrastructure.fedoraproject.org/5/SRPMS/">RHEL5 Production SRPMS</a></li>
+                <li><a href="https://infrastructure.fedoraproject.org/6/SRPMS/">RHEL6 Production SRPMS</a></li>
             </ul>
           </div>
         </div>

--- a/fedoracommunity/widgets/package/templates/package_chrome.mak
+++ b/fedoracommunity/widgets/package/templates/package_chrome.mak
@@ -55,7 +55,7 @@ icon_url = tg.url("/images/icons/%s.png" % icon)
 	           <li><a class="other-app" href="https://admin.fedoraproject.org/updates/${w.package_info['name']}"><img src ="https://admin.fedoraproject.org/community/images/16_bodhi.png"/> Bodhi </a> </li>
                    <li><a class="other-app" href="http://koji.fedoraproject.org/koji/search?match=glob&type=package&terms=${w.package_info['name']}"><img src = "https://fedoraproject.org/static/images/icons/fedora-infra-icon_koji.png"/> Koji Builds </a> </li>
                    <li><a class="other-app" href="https://bugzilla.redhat.com/buglist.cgi?component=${w.package_info['name']}&query_format=advanced&product=Fedora&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED"><img src = "https://admin.fedoraproject.org/community/images/16_bugs.png"/> Bugzilla </a> </li>
-                   <li><a class="other-app" href="http://pkgs.fedoraproject.org/cgit/${w.package_info['name']}.git"><img src = "https://apps.fedoraproject.org/img/icons/git-logo.png"/> SCM </a> </li>
+                   <li><a class="other-app" href="https://pkgs.fedoraproject.org/cgit/${w.package_info['name']}.git"><img src = "https://apps.fedoraproject.org/img/icons/git-logo.png"/> SCM </a> </li>
                    <li><a class="other-app" href="https://admin.fedoraproject.org/pkgdb/package/${w.package_info['name']}"><img src = "https://fedoraproject.org/static/images/icons/fedora-infra-icon_pkgdb.png"/> Pkgdb Package Info </a></li>
                    <li><a class="other-app" href="https://apps.fedoraproject.org/tagger/${w.package_info['name']}"><img src = "${tg.url('/images/16_tagger.png')}"/> Tagger </a></li>
                  </ul>

--- a/fedoracommunity/widgets/package/templates/patch.mak
+++ b/fedoracommunity/widgets/package/templates/patch.mak
@@ -21,7 +21,7 @@
 ${render_diffstat(w.diffstat)}
 % endif
 <div class="patch_raw">
-<a href="http://pkgs.fedoraproject.org/cgit/${w.package}.git/tree/${w.patch}" target="_blank">Link to raw patch</a>
+<a href="https://pkgs.fedoraproject.org/cgit/${w.package}.git/tree/${w.patch}" target="_blank">Link to raw patch</a>
 </div>
 <br/>
 ${w.text}


### PR DESCRIPTION
Most fedoraproject servers have good or perfect SSL setup. Link to SSL for those.

Koji doesn't have a trusted SSL cert, so there is no way to use SSL there. Some of the python files may need updates to https, but I don't know the code and don't want to break things.

besides: fedoracommunity/plugins/extensions/patchspecinfo.js refers to http://cvs.fedoraproject.org/ which doesn't exist anymore afaik.