### PR TITLE
Remove broken link from the builds tab.

### DIFF
--- a/fedoracommunity/widgets/package/templates/builds_table_widget.mak
+++ b/fedoracommunity/widgets/package/templates/builds_table_widget.mak
@@ -35,8 +35,7 @@
                           <div id="menu_${'${build_id}'}" class="menu" panel="menu_panel_${'${build_id}'}">
                             <span class="package-name">
                                 <% icon = tg.url("/images/16_build_state_${state}.png") %>
-                                <img src="${icon}"></img>
-                                <a href="/package_maintenance/tools/builds?package=${'${package_name}'}" moksha_url="dynamic">${'${package_name}'} </a>
+                                <img src="${icon}"></img>&nbsp;${'${package_name}'}
                             </span>
                             <br/>${'${version}'}-${'${release}'}&nbsp;
                             <div id="menu_panel_${'${build_id}'}" class="menu_panel" >


### PR DESCRIPTION
I have no clue where this link was ever supposed to go.

Grepping around the sourcecode, I happened to notice that there are some old marketing pages tucked in a directory (with pictures of mike mcgrath) and they have references to that package_maint url, but it doesn't make sense.  I'm just removing it.

Fixes #168.