### PR TITLE
Fix markdown usage on rhel6.

### DIFF
--- a/fedoracommunity/connectors/bodhiconnector.py
+++ b/fedoracommunity/connectors/bodhiconnector.py
@@ -366,9 +366,7 @@ class BodhiConnector(IConnector, ICall, IQuery):
                     if comment['text'].startswith('This update has been '
                                                   'obsoleted by '):
                         details += markdown.markdown(
-                            comment['text'],
-                            safe_mode="replace",
-                            html_replacement_text="--RAW HTML NOT ALLOWED--")
+                            comment['text'], safe_mode="replace")
         return details
 
     def _get_update_actions(self, update):


### PR DESCRIPTION
The version of python-markdown on rhel6 is too old and doesn't know
about the ``html_replacement_text`` argument.

By removing it like we're doing here, do we open ourselves up to attack?
No.  If we were embedding comments from *any user* from bodhi, yes.
They could inject JS-bearing HTML in a comment, that could do malicious
things to our users over here.  However, we're not embedding comments
from just *any* user -- only from the *bodhi* system user, which we can
trust.