### PR TITLE
Add a mechanism to update the xapian db on pkgdb changes.

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -31,6 +31,9 @@ fedoracommunity.connector.bugzilla.baseurl = https://bugzilla.redhat.com/xmlrpc.
 fedoracommunity.connector.fas.baseurl = https://admin.fedoraproject.org/accounts/
 fedoracommunity.connector.bodhi.baseurl = https://bodhi.fedoraproject.org
 fedoracommunity.connector.pkgdb.baseurl = https://admin.fedoraproject.org/pkgdb
+fedoracommunity.connector.tagger.baseurl = https://apps.fedoraproject.org/tagger
+fedoracommunity.connector.mdapi.baseurl = http://209.132.184.236
+fedoracommunity.connector.icons.baseurl = https://alt.fedoraproject.org/pub/alt/screenshots
 fedoracommunity.connector.yum.conf = %(here)s/production/yum.conf
 fedoracommunity.rpm_cache = %(here)s/rpm_cache/
 

--- a/fedoracommunity/consumers.py
+++ b/fedoracommunity/consumers.py
@@ -1,3 +1,5 @@
+import json
+
 import memcache
 import pkg_resources
 
@@ -16,6 +18,7 @@ from fedoracommunity.connectors.api.connector import (
 from fedoracommunity.connectors.api.worker import (
     find_config_file,
 )
+from fedoracommunity.search import utils
 
 import logging
 log = logging.getLogger("fedmsg")
@@ -38,13 +41,11 @@ def make_kwargs(connector, path, info, filters):
     return kwargs
 
 
-
 class CacheInvalidator(fedmsg.consumers.FedmsgConsumer):
     topic = '*'
     config_key = 'fedoracommunity.fedmsg.consumer.enabled'
 
     def __init__(self, hub, *args, **kwargs):
-
         config = appconfig("config:" + find_config_file())
         tg.config.update(config)
 
@@ -52,6 +53,22 @@ class CacheInvalidator(fedmsg.consumers.FedmsgConsumer):
         if url_key not in config:
             raise ValueError("%r not in config and is required.")
         self.mc = memcache.Client([config[url_key]])
+
+        self.cache_path = config.get(
+            'fedoracommunity.connector.xapian.package-search.db',
+            'xapian')
+        self.tagger_url = config.get(
+            'fedoracommunity.connector.tagger.baseurl',
+            'https://apps.fedoraproject.org/tagger')
+        self.mdapi_url = config.get(
+            'fedoracommunity.connector.mdapi.baseurl',
+            'http://209.132.184.236')  # dev instance
+        self.pkgdb_url = config.get(
+            'fedoracommunity.connector.pkgdb.baseurl',
+            'https://admin.fedoraproject.org/pkgdb')
+        self.icons_url = config.get(
+            'fedoracommunity.connector.icons.baseurl',
+            'https://alt.fedoraproject.org/pub/alt/screenshots')
 
         self._load_connectors()
 
@@ -68,6 +85,10 @@ class CacheInvalidator(fedmsg.consumers.FedmsgConsumer):
 
     def consume(self, msg):
         msg = msg['body']
+        self.update_xapian(msg)
+        self.update_caches(msg)
+
+    def update_caches(self, msg):
         for conn_name, connector in self.connectors.items():
             for path, info in connector._cache_prompts.items():
 
@@ -84,9 +105,81 @@ class CacheInvalidator(fedmsg.consumers.FedmsgConsumer):
                     kwargs = make_kwargs(connector, path, info, filters)
                     lookup_key = generator(**kwargs)
                     hashed_key = mangler(lookup_key)
-                    log.info("Updating %s" % lookup_key)
-                    log.debug("    hash %s" % hashed_key)
+                    log.info("Refreshing %s" % lookup_key)
                     # Destroy the old value
                     self.mc.delete(hashed_key)
                     # Run the connector to re-fill the cache.
                     fn(*args, **kwargs)
+                    log.info(" Done with %s" % hashed_key)
+
+    def update_xapian(self, msg):
+        # If any number of different pkgdb things happen to a package, let's
+        # just update and not care too much about whatever it was that just
+        # happened.
+        if '.pkgdb.' not in msg['topic']:
+            return
+
+        # This one is spammy
+        if '.pkgdb.acl.update' in msg['topic']:
+            return
+
+        # We'll take all others, so long as they have this field.
+        if not 'package_listing' in msg['msg']:
+            return
+
+        name = msg['msg']['package_listing']['package']['name']
+        log.info("Considering xapian index updates for %r" % name)
+
+        from fedoracommunity.search import index
+        indexer = index.Indexer(
+            cache_path=self.cache_path,
+            tagger_url=self.tagger_url,
+            pkgdb_url=self.pkgdb_url,
+            mdapi_url=self.mdapi_url,
+            icons_url=self.icons_url,
+        )
+
+        indexer.pull_icons()
+        indexer.cache_icons()
+        try:
+            package = indexer.construct_package_dictionary(dict(name=name))
+
+            if package is None:
+                log.warn("Unable to construct xapian pkg dict for %r" % name)
+                return
+
+            document = indexer._create_document(package)
+            processed = indexer._process_document(package, document)
+
+            old_document = self._get_old_document(name)
+            if old_document:
+                docid = old_document.get_docid()
+                log.debug('Deleting old document %r.' % docid)
+                indexer.indexer.delete(xapid=docid)
+
+            indexer.indexer.add(processed)
+            log.info("Done adding new document %r" % name)
+        finally:
+            indexer.indexer.close()
+
+    def _get_old_document(self, package_name):
+        search_name = utils.filter_search_string(package_name)
+        search_string = "%s EX__%s__EX" % (search_name, search_name)
+        matches = self._xapian_connector().do_search(search_string, 0, 10)
+
+        for match in matches:
+            result = json.loads(match.document.get_data())
+            if result['name'] == package_name:
+                return match.document
+
+        return None
+
+    def _xapian_connector(self):
+        request = FakeTG2Request()
+        for conn_entry in pkg_resources.iter_entry_points('fcomm.connector'):
+            if conn_entry.name == 'xapian':
+                cls = conn_entry.load()
+                cls.register()
+                return cls(request.environ, request)
+
+        raise ValueError("No Xapian connector could be found.")

--- a/fedoracommunity/search/index.py
+++ b/fedoracommunity/search/index.py
@@ -71,6 +71,7 @@ class Indexer(object):
         self.icons_url = icons_url or "https://alt.fedoraproject.org/pub/alt/screenshots"
         self._latest_release = None
         self._active_fedora_releases = None
+        self.icon_cache = {}
 
         self.create_index()
 
@@ -180,7 +181,6 @@ class Indexer(object):
                 download_file(url, target)
 
     def cache_icons(self):
-        self.icon_cache = {}
         for release in self.active_fedora_releases:
             fname = 'fedora-%i.xml.gz' % release
             target = join(self.icons_path, 'tmp', str(release), fname)
@@ -421,7 +421,6 @@ class Indexer(object):
             self.indexer.add(document)
 
         self.indexer.close()
-        return i + 1
 
     def _process_document(self, package, document):
         processed = self.indexer.process(document, False)
@@ -499,8 +498,8 @@ def run(cache_path, tagger_url=None, pkgdb_url=None, mdapi_url=None, icons_url=N
     indexer.cache_icons()
 
     log.info("Indexing packages.")
-    count = indexer.index_packages()
-    log.info("Indexed %d packages." % count)
+    indexer.index_packages()
+    log.info("Indexed a ton of packages.")
 
 if __name__ == '__main__':
     run('index_cache', join(os.path.dirname(__file__), 'yum.conf'), 'http://apps.fedoraproject.org/tagger/dump')


### PR DESCRIPTION
I think this might be the final major change for this dev cycle.

This:

- Listens for pkgdb messages.
- When they show up, create a new xapian document for that package.
- Remove the old one if it exists.
- Add the new one.

I tested it locally and it can seamlessly update the xapian db while the web server is serving read-only queries to it.

One thing it *cannot* do, is run simultaneously while the fcomm-index-packages cronjob is running (the one that rebuilds the whole thing from scratch and takes 4 hours).

The nice thing is.. with *this* in place, we don't need *any* cronjobs anymore.. so that shouldn't be an issue.  We'll run that script once to rebuild the index from scratch, and then set this to run in the background all the time.