### PR TITLE
Update xapian index when pkgdb_updater changes things like upstream_url.

### DIFF
--- a/fedoracommunity/consumers.py
+++ b/fedoracommunity/consumers.py
@@ -154,11 +154,15 @@ class CacheInvalidator(fedmsg.consumers.FedmsgConsumer):
         if '.pkgdb.acl.update' in msg['topic']:
             return
 
-        # We'll take all others, so long as they have this field.
-        if not 'package_listing' in msg['msg']:
+        # We'll take all others, so long as they have these fields.
+        if 'package_listing' in msg['msg']:
+            name = msg['msg']['package_listing']['package']['name']
+        elif 'package' in msg['msg']:
+            name = msg['msg']['package']['name']
+        else:
+            # If the message doesn't have either of those two, then give up.
             return
 
-        name = msg['msg']['package_listing']['package']['name']
         log.info("Considering xapian index updates for %r" % name)
 
         indexer = self.try_real_hard_to_get_the_xapian_indexer()


### PR DESCRIPTION
See [this question](https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/NLGVT37LIKZ7OCK2MNXMHTBR5OXXRNCK/) on the devel list.

We should be updating our xapian documents in response to [messages like this one](https://apps.fedoraproject.org/datagrepper/id?id=2015-d84267ec-10ae-41db-b4dc-d777e796771e&is_raw=true&size=extra-large).

This should make that happen.