### PR TITLE
Use src.fedoraproject.org instead of pkgs.fp.o

### DIFF
--- a/fedoracommunity/connectors/gitconnector.py
+++ b/fedoracommunity/connectors/gitconnector.py
@@ -153,7 +153,7 @@ class FedoraGitRepo(object):
 
     def get_fedora_source(self):
         url = config.get(
-            'fedora_lookaside', 'http://pkgs.fedoraproject.org/repo/pkgs')
+            'fedora_lookaside', 'https://src.fedoraproject.org/repo/pkgs')
         source = self.get_source_url()
         if source:
             tarball = source.split('/')[-1]

--- a/fedoracommunity/widgets/package/templates/package_chrome.mak
+++ b/fedoracommunity/widgets/package/templates/package_chrome.mak
@@ -58,7 +58,7 @@ icon_url = tg.url("/images/icons/%s" % icon)
                    <li><a class="other-app" href="https://retrace.fedoraproject.org/faf/problems/?component_names=${w.package_info['name']}"><img src = "https://admin.fedoraproject.org/community/images/16_abrt.png"/> FAF </a> </li>
                    <li><a class="other-app" href="http://koji.fedoraproject.org/koji/search?match=glob&type=package&terms=${quote(w.package_info['name'])}"><img src = "https://fedoraproject.org/static/images/icons/fedora-infra-icon_koji.png"/> Koji Builds </a> </li>
                    <li><a class="other-app" href="https://admin.fedoraproject.org/pkgdb/package/${w.package_info['name']}"><img src = "https://fedoraproject.org/static/images/icons/fedora-infra-icon_pkgdb.png"/> Pkgdb Package Info </a></li>
-                   <li><a class="other-app" href="https://pkgs.fedoraproject.org/cgit/${w.package_info['name']}.git"><img src = "https://apps.fedoraproject.org/img/icons/git-logo.png"/> SCM </a> </li>
+                   <li><a class="other-app" href="https://src.fedoraproject.org/cgit/${w.package_info['name']}.git"><img src = "https://apps.fedoraproject.org/img/icons/git-logo.png"/> SCM </a> </li>
                    <li><a class="other-app" href="https://apps.fedoraproject.org/tagger/${w.package_info['name']}"><img src = "${tg.url('/images/16_tagger.png')}"/> Tagger </a></li>
                  </ul>
              </div>

--- a/fedoracommunity/widgets/package/templates/patch.mak
+++ b/fedoracommunity/widgets/package/templates/patch.mak
@@ -21,7 +21,7 @@
 ${render_diffstat(w.diffstat)}
 % endif
 <div class="patch_raw">
-<a href="https://pkgs.fedoraproject.org/cgit/${w.package}.git/tree/${w.patch}" target="_blank">Link to raw patch</a>
+<a href="https://src.fedoraproject.org/cgit/${w.package}.git/tree/${w.patch}" target="_blank">Link to raw patch</a>
 </div>
 <br/>
 ${w.text}


### PR DESCRIPTION
Since the FlagDay2016 the new domain should be available with a well known certificate, avoiding a browser warning for untrusted certificate on the old domain.