### PR TITLE
change koji link in development.ini to https

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -26,7 +26,7 @@ profile.dir = profile
 # setup the applications
 fedoracommunity.extensions_dir = %(here)s/fedoracommunity/plugins/extensions
 
-fedoracommunity.connector.kojihub.baseurl = http://koji.fedoraproject.org/kojihub
+fedoracommunity.connector.kojihub.baseurl = https://koji.fedoraproject.org/kojihub
 fedoracommunity.connector.bugzilla.baseurl = https://bugzilla.redhat.com/xmlrpc.cgi
 fedoracommunity.connector.fas.baseurl = https://admin.fedoraproject.org/accounts/
 fedoracommunity.connector.bodhi.baseurl = https://bodhi.fedoraproject.org
@@ -152,4 +152,3 @@ formatter = generic
 [formatter_generic]
 format = %(asctime)s,%(msecs)03d %(levelname)-5.5s [%(name)s] %(message)s
 datefmt = %H:%M:%S
-


### PR DESCRIPTION
When trying to use the development.ini as a base to test fedora-packages, any information from koji would not appear, and errors similar to the one attached below are presented in the console.

Changing the koji link in the development.ini to https fixes this issue.

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/tg/support/registry.py", line 249, in __call__
    app_iter = self.application(environ, start_response)
  File "/usr/lib/python2.7/site-packages/tg/support/middlewares.py", line 68, in __call__
    status, headers, app_iter, exc_info = _call_wsgi_application(self.app, environ)
  File "/usr/lib/python2.7/site-packages/tg/support/middlewares.py", line 24, in _call_wsgi_application
    app_iter = application(environ, start_response)
  File "/usr/lib/python2.7/site-packages/tw2/core/middleware.py", line 204, in __call__
    resp = req.get_response(self.app, catch_exc_info=True)
  File "/usr/lib/python2.7/site-packages/webob/request.py", line 1313, in send
    application, catch_exc_info=True)
  File "/usr/lib/python2.7/site-packages/webob/request.py", line 1281, in call_application
    app_iter = application(self.environ, start_response)
  File "/usr/lib/python2.7/site-packages/beaker/middleware.py", line 73, in __call__
    return self.app(environ, start_response)
  File "/usr/lib/python2.7/site-packages/beaker/middleware.py", line 152, in __call__
    return self.wrap_app(environ, session_start_response)
  File "/usr/lib/python2.7/site-packages/paste/registry.py", line 379, in __call__
    app_iter = self.application(environ, start_response)
  File "/usr/lib/python2.7/site-packages/moksha/wsgi/middleware/middleware.py", line 76, in __call__
    return self.application(environ, start_response)
  File "/usr/lib/python2.7/site-packages/moksha/wsgi/middleware/extensionpoint.py", line 232, in __call__
    response = request.get_response(self.application)
  File "/usr/lib/python2.7/site-packages/webob/request.py", line 1317, in send
    application, catch_exc_info=False)
  File "/usr/lib/python2.7/site-packages/webob/request.py", line 1281, in call_application
    app_iter = application(self.environ, start_response)
  File "/vagrant/fedoracommunity/connectors/api/mw.py", line 130, in __call__
    **params)
  File "/vagrant/fedoracommunity/connectors/api/mw.py", line 242, in _run_connector
    op, path, remote_params, **dispatch_params)
  File "/vagrant/fedoracommunity/connectors/api/connector.py", line 162, in _dispatch
    return getattr(self, op)(resource_path, params, _cookies, **kwds)
  File "/vagrant/fedoracommunity/connectors/api/connector.py", line 351, in query
    **params)
  File "/usr/lib/python2.7/site-packages/dogpile/cache/region.py", line 1040, in decorate
    should_cache_fn)
  File "/usr/lib/python2.7/site-packages/dogpile/cache/region.py", line 651, in get_or_create
    async_creator) as value:
  File "/usr/lib/python2.7/site-packages/dogpile/core/dogpile.py", line 158, in __enter__
    return self._enter()
  File "/usr/lib/python2.7/site-packages/dogpile/core/dogpile.py", line 98, in _enter
    generated = self._enter_create(createdtime)
  File "/usr/lib/python2.7/site-packages/dogpile/core/dogpile.py", line 149, in _enter_create
    created = self.creator()
  File "/usr/lib/python2.7/site-packages/dogpile/cache/region.py", line 619, in gen_value
    created_value = creator()
  File "/usr/lib/python2.7/site-packages/dogpile/cache/region.py", line 1036, in creator
    return fn(*arg, **kw)
  File "/vagrant/fedoracommunity/connectors/bodhiconnector.py", line 558, in query_active_releases
    results = koji.multiCall()
  File "/usr/lib/python2.7/site-packages/koji/__init__.py", line 2167, in multiCall
    ret = self._callMethod('multiCall', (calls,), {})
  File "/usr/lib/python2.7/site-packages/koji/__init__.py", line 2099, in _callMethod
    return self._sendCall(handler, headers, request)
  File "/usr/lib/python2.7/site-packages/koji/__init__.py", line 2010, in _sendCall
    return self._sendOneCall(handler, headers, request)
  File "/usr/lib/python2.7/site-packages/koji/__init__.py", line 2032, in _sendOneCall
    ret = self._read_xmlrpc_response(response, handler)
  File "/usr/lib/python2.7/site-packages/koji/__init__.py", line 2064, in _read_xmlrpc_response
    response.status, response.reason, response.msg)
ProtocolError: <ProtocolError for koji.fedoraproject.org/kojihub: 302 Found>
```