### PR TITLE
Use f25 in the vagrant env

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,8 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/23/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-23-20151030.x86_64.vagrant-libvirt.box"
-  config.vm.box = "f23-cloud-libvirt"
+  config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/25/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-25-1.3.x86_64.vagrant-libvirt.box"
+  config.vm.box = "f25-cloud-libvirt"
   config.vm.network "forwarded_port", guest: 8080, host: 8080
   config.vm.synced_folder ".", "/vagrant", type: "sshfs"
   # Ansible needs the guest to have these

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -34,6 +34,7 @@
   with_items:
       - python-appstream
       - gearbox
+      - crank==0.7.3
 
 - command: "{{ item }}"
   become: yes


### PR DESCRIPTION
Use f25 in the vagrant environment. crank need to be set to 0.7.x for TurboGears2

Signed-off-by: Clement Verna <cverna@tutanota.com>