### PR TITLE
Replace python-appstream by the Gobject python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ https://fedorahosted.org/fedoracommunity/wiki/Development
 
 Note: Some more dependencies to be installed:-
 
-    $ sudo dnf install python-webhelpers fedmsg
+    $ sudo dnf install python-webhelpers fedmsg pygobject3
 
-    $ pip install python-appstream gearbox
+    $ pip install gearbox
 
 ### Hacking with Vagrant
 

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -26,13 +26,13 @@
       - python-memcached
       - memcached
       - python-markdown
+      - pygobject3
 
 - name: Install python packages
   pip:
       name: "{{ item }}"
       state: present
   with_items:
-      - python-appstream
       - gearbox
       - crank==0.7.3
 

--- a/fedora-packages.spec
+++ b/fedora-packages.spec
@@ -37,7 +37,7 @@ BuildRequires: python-dogpile-core > 0.4.0
 BuildRequires: python-dogpile-cache > 0.4.1
 BuildRequires: python-memcached
 BuildRequires: python-markdown
-BuildRequires: python-appstream
+BuildRequires: pygobject3
 BuildRequires: fedmsg
 BuildRequires: python-daemon
 
@@ -72,7 +72,7 @@ Requires: python-dogpile-cache > 0.4.1
 Requires: python-memcached
 Requires: packagedb-cli
 Requires: python-markdown
-Requires: python-appstream
+Requires: pygobject3
 Requires: fedmsg
 # For spectool
 Requires: rpmdevtools

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ setup(
         "dogpile.cache",
         "python-memcached",
         "markdown",
-        "python-appstream",
         "fedmsg",
         #"PyOpenSSL",
         #"SQLAlchemy>=0.5",


### PR DESCRIPTION
This commit replace python-appstream by PyGobject. This needed in order to deploy fedora-packages to rhel7. It also update the development environment.

Signed-off-by: Clement Verna <cverna@tutanota.com>