### PR TITLE
Making the indexing more robust.

### DIFF
--- a/fedoracommunity/search/index.py
+++ b/fedoracommunity/search/index.py
@@ -280,8 +280,13 @@ class Indexer(object):
                     latest_version = version
                     branch_info = branch
 
-
         if latest_version is None:
+            # Check if we are a subpackage, if so run latest_active with the main package name
+            kwargs = {'name': name}
+            for comp in pdc.get_paged(pdc['rpms']._, **kwargs):
+                branch_info = self.latest_active(comp.get('srpm_name'))
+                return branch_info
+
             raise ValueError('There is no active branch tied to a Fedora release')
         return branch_info
 

--- a/fedoracommunity/search/index.py
+++ b/fedoracommunity/search/index.py
@@ -248,7 +248,7 @@ class Indexer(object):
         shutil.rmtree(join(self.icons_path, 'tmp'))
 
     def gather_pdc_packages(self, pkg_name=None):
-        pdc = pdc_client.PDCClient(self.pdc_url, develop=True)
+        pdc = pdc_client.PDCClient(self.pdc_url, develop=True, page_size=100)
         
         kwargs = dict()
         if pkg_name is not None:


### PR DESCRIPTION
This PR is making the indexing of the xapian index more robust.

* First commit improve the speed of the fetching the packages asking pdc for 100 results per pages instead of 20. That will also reduce the number of requests to pdc.
* Second commit add some way to handle failure in mdapi.
* Thrid commit is to try to get the branch information from the main package in case the don't any information for the subpacke in pdc.