### PR TITLE
The new indexing get the full name of the icons with the .png

### DIFF
--- a/fedoracommunity/templates/header.mak
+++ b/fedoracommunity/templates/header.mak
@@ -67,7 +67,7 @@
                    datum = {
                      'name': strip(row['name']),
                      'value': strip(row['name']),
-                     'icon': "${tg.url('/images/icons/')}" + row['icon'] + ".png"
+                     'icon': "${tg.url('/images/icons/')}" + row['icon']
                    };
                    thing.push(datum);
                  }


### PR DESCRIPTION
We don't need to add the .png extension in the template since the icon name is indexed with .png

Signed-off-by: Clement Verna <cverna@tutanota.com>