### PR TITLE
Delete the old document after an update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ command to reload the application to test some code changes.
 
 This will change the timestamp of the .wsgi file and ask apache to reload the application.
 
+#### Running the unit tests
+To execute the test suite simply run the following command
+
+	$ docker-compose exec web py.test /usr/share/fedoracommunity/tests
+
 
 ### Hacking with Vagrant
 

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,0 +1,13 @@
+#
+# Fedora Packages - unit test configuration
+#
+[DEFAULT]
+fedoracommunity.connector.xapian.package-search.db = /tmp/xapian/search
+
+cache.connectors.backend=dogpile.cache.memcached
+cache.connectors.expiration_time=30
+cache.connectors.arguments.url=127.0.0.1:11211
+cache.connectors.arguments.distributed_lock=False
+
+[app:main]
+use = egg:fedoracommunity

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -1,0 +1,138 @@
+import fedmsg.config
+import json
+import mock
+import pytest
+import pytest_mock
+import xapian
+
+from fedoracommunity.consumers import CacheInvalidator
+
+msg = {
+  "topic": "org.fedoraproject.prod.mdapi.repo.update",
+  "msg": {
+    "packages": ["guake"]}
+  }
+
+pkg_guake = {'name': 'guake',
+            'summary': 'Drop-down terminal for GNOME',
+            'description': 'Guake is a drop-down terminal for Gnome Desktop Environment',
+            'devel_owner': 'pingou',
+            'icon': 'guake',
+            'package': None,
+            'upstream_url': 'http://guake.org/',
+            'sub_pkgs': []
+           }
+
+
+class MockHub(mock.MagicMock):
+    """ Class that mock a fedmsg hub """
+    config = fedmsg.config.load_config()
+    config['fedoracommunity.fedmsg.consumer.enabled'] = True
+
+
+@pytest.fixture(scope='module')
+def create_xapian_db():
+    """ Fixture that creates an empty xapian db """
+
+    db = xapian.WritableDatabase('/tmp/xapian/search', xapian.DB_CREATE_OR_OPEN)
+    db.close()
+
+
+def test_CacheInvalidator_new_package(create_xapian_db, mocker):
+    """ Test that the update_xapian method
+    creates a new xapian document when we receive
+    an update from a new package.
+    """
+    mocker.patch('fedoracommunity.consumers.find_config_file',
+                 return_value='/usr/share/fedoracommunity/tests/config.py')
+    mocker.patch('fedoracommunity.search.index.Indexer.pull_icons')
+    mocker.patch('fedoracommunity.search.index.Indexer.cache_icons')
+    mocker.patch('fedoracommunity.search.index.Indexer.index_files_of_interest')
+    mocker.patch(
+        'fedoracommunity.search.index.Indexer.construct_package_dictionary',
+        return_value=pkg_guake)
+
+    consumer = CacheInvalidator(MockHub())
+    consumer.update_xapian(msg)
+    db = xapian.Database('/tmp/xapian/search')
+    last_doc = db.get_lastdocid()
+    data = json.loads(db.get_document(last_doc).get_data())
+    assert data['name'] == 'guake'
+    assert data['devel_owner'] == 'pingou'
+    assert db.get_doccount() == 1
+
+
+def test_CacheInvalidator_update_package(mocker):
+    """ Test that the update_xapian method updates
+    the xapian document when we recieve an update from
+    fedmsg """
+
+    pkg_guake_update = {'name': 'guake',
+                        'summary': 'Drop-down terminal for GNOME',
+                        'description': 'Guake is a drop-down terminal for Gnome Desktop Environment',
+                        'devel_owner': 'cverna',
+                        'icon': 'guake',
+                        'package': None,
+                        'upstream_url': 'http://guake.org/',
+                        'sub_pkgs': []
+                       }
+    mocker.patch('fedoracommunity.consumers.find_config_file',
+                 return_value='/usr/share/fedoracommunity/tests/config.py')
+    mocker.patch('fedoracommunity.search.index.Indexer.pull_icons')
+    mocker.patch('fedoracommunity.search.index.Indexer.cache_icons')
+    mocker.patch('fedoracommunity.search.index.Indexer.index_files_of_interest')
+    mocker.patch(
+        'fedoracommunity.search.index.Indexer.construct_package_dictionary',
+        return_value=pkg_guake_update)
+
+    consumer = CacheInvalidator(MockHub())
+    consumer.update_xapian(msg)
+    db = xapian.Database('/tmp/xapian/search')
+    last_doc = db.get_lastdocid()
+    data = json.loads(db.get_document(last_doc).get_data())
+    assert data['name'] == 'guake'
+    # POC was successfully updated
+    assert data['devel_owner'] == 'cverna'
+    # We still have only one document in the database
+    assert db.get_doccount() == 1
+
+
+@pytest.fixture(params=
+    [{"topic": "org.fedoraproject.prod.mdapi.wrong.topic",
+      "msg": {"packages": ["guake"]}},
+    {"topic": "org.fedoraproject.prod.mdapi.repo.update",
+      "msg": {"wrong": ["guake"]}},
+    {"topic": "org.fedoraproject.prod.mdapi.repo.update",
+      "msg": {"wrong": [""]}},
+    ])
+def test_wrong_fedmsg(request):
+    return request.param
+
+
+def test_CacheInvalidator_wrong_fedmsg(mocker, test_wrong_fedmsg):
+    """ Test that the update_xapian method
+    returns whith a wrong fedmsg message
+    Case 1 : Wrong topic
+    Case 2 : Wrong msg format
+    Case 3 : No package name in the msg
+    """
+
+    mocker.patch('fedoracommunity.consumers.find_config_file',
+                 return_value='/usr/share/fedoracommunity/tests/config.py')
+    mocker.patch('fedoracommunity.search.index.Indexer.pull_icons')
+    mocker.patch('fedoracommunity.search.index.Indexer.cache_icons')
+    mocker.patch('fedoracommunity.search.index.Indexer.index_files_of_interest')
+    mocker.patch(
+        'fedoracommunity.search.index.Indexer.construct_package_dictionary',
+        return_value=pkg_guake)
+
+    consumer = CacheInvalidator(MockHub())
+    consumer.update_xapian(test_wrong_fedmsg)
+
+    db = xapian.Database('/tmp/xapian/search')
+    last_doc = db.get_lastdocid()
+    data = json.loads(db.get_document(last_doc).get_data())
+    # POC was not changed
+    assert data['devel_owner'] == 'cverna'
+    # We still have only one document in the database
+    assert db.get_doccount() == 1


### PR DESCRIPTION
This commit makes sure that the old document is deleted
after an update. So that we do not duplicate documents.
Xapian supports a replace_document API but it seems to
create a new document anyway, so this commit switch back
to Xapian add_document delete_document API.

Introduce unit tests to check the logic of the db update.

Signed-off-by: Clement Verna <cverna@tutanota.com>