### PR TITLE
Add Fedora Modules to bugzilla allowed products list

### DIFF
--- a/fedoracommunity/connectors/bugzillaconnector.py
+++ b/fedoracommunity/connectors/bugzillaconnector.py
@@ -32,7 +32,7 @@ from bugzillahacks import hotpatch_bugzilla
 # Do it at import-time.
 hotpatch_bugzilla()
 
-PRODUCTS = ['Fedora', 'Fedora EPEL']
+PRODUCTS = ['Fedora', 'Fedora EPEL', 'Fedora Modules']
 
 # Don't query closed bugs for these packages, since the queries timeout
 BLACKLIST = ['kernel']


### PR DESCRIPTION
Add Fedora Modules to bugzilla allowed products list

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>