### PR TITLE
Resolving #350 -- adding product FedoraEPEL to the bz string

### DIFF
--- a/fedoracommunity/widgets/package/bugs.py
+++ b/fedoracommunity/widgets/package/bugs.py
@@ -24,7 +24,7 @@ class BugStatsWidget(twc.Widget):
     def prepare(self):
         super(BugStatsWidget, self).prepare()
         # To get more than one key/value pair with the same key in urllib.urlencode, we need to create a tuple first
-        query_product = (
+        self.query_product = (
             ("query_format", "advanced"),
             ("product", "Fedora"), 
             ("product", "FedoraEPEL"),

--- a/fedoracommunity/widgets/package/bugs.py
+++ b/fedoracommunity/widgets/package/bugs.py
@@ -10,7 +10,11 @@ class BugStatsWidget(twc.Widget):
     template = "mako:fedoracommunity.widgets.package.templates.bugs_stats_widget"
     id = twc.Param(default='bugs_widget')
     kwds = twc.Param(default=None)
-    product = twc.Param(default='Fedora')
+    # To get more than one key/value pair with the same key in urllib.urlencode, we need to create a tuple first
+    query_product = (
+        ("query_format", "advanced"),
+        ("product", "Fedora"), 
+        ("product", "FedoraEPEL"))
     version = twc.Param(default='rawhide')
     epel_version = twc.Param(default='epel7')
     num_open = twc.Param(default='-')
@@ -20,15 +24,11 @@ class BugStatsWidget(twc.Widget):
     status_closed_string = "bug_status=CLOSED"
 
     base_query_string = twc.Variable(default='')
-
+    
     def prepare(self):
         super(BugStatsWidget, self).prepare()
-        self.base_query_string = urllib.urlencode({
-            "query_format": "advanced",
-            "product": self.product,
-            "component": self.package,
-        })
-
+        # Here we use the tuple and the package to create a string for bugzilla
+        self.base_query_string = urllib.urlencode(self.query_product, {"component":self.package})
 
 class BugsGrid(Grid):
     resource = 'bugzilla'

--- a/fedoracommunity/widgets/package/bugs.py
+++ b/fedoracommunity/widgets/package/bugs.py
@@ -10,11 +10,7 @@ class BugStatsWidget(twc.Widget):
     template = "mako:fedoracommunity.widgets.package.templates.bugs_stats_widget"
     id = twc.Param(default='bugs_widget')
     kwds = twc.Param(default=None)
-    # To get more than one key/value pair with the same key in urllib.urlencode, we need to create a tuple first
-    query_product = (
-        ("query_format", "advanced"),
-        ("product", "Fedora"), 
-        ("product", "FedoraEPEL"))
+
     version = twc.Param(default='rawhide')
     epel_version = twc.Param(default='epel7')
     num_open = twc.Param(default='-')
@@ -27,8 +23,14 @@ class BugStatsWidget(twc.Widget):
     
     def prepare(self):
         super(BugStatsWidget, self).prepare()
+        # To get more than one key/value pair with the same key in urllib.urlencode, we need to create a tuple first
+        query_product = (
+            ("query_format", "advanced"),
+            ("product", "Fedora"), 
+            ("product", "FedoraEPEL"),
+            ("component", self.package))
         # Here we use the tuple and the package to create a string for bugzilla
-        self.base_query_string = urllib.urlencode(self.query_product, {"component":self.package})
+        self.base_query_string = urllib.urlencode(self.query_product)
 
 class BugsGrid(Grid):
     resource = 'bugzilla'

--- a/fedoracommunity/widgets/package/bugs.py
+++ b/fedoracommunity/widgets/package/bugs.py
@@ -27,7 +27,7 @@ class BugStatsWidget(twc.Widget):
         self.query_product = (
             ("query_format", "advanced"),
             ("product", "Fedora"), 
-            ("product", "FedoraEPEL"),
+            ("product", "Fedora EPEL"),
             ("component", self.package))
         # Here we use the tuple and the package to create a string for bugzilla
         self.base_query_string = urllib.urlencode(self.query_product)


### PR DESCRIPTION
This resolves #350 by using some trickery to get more than one key/value pair with the same key to get into the bugzilla string.