### PR TITLE
OpenSearch integration

### DIFF
--- a/fedoracommunity/controllers/root.py
+++ b/fedoracommunity/controllers/root.py
@@ -74,6 +74,14 @@ class RootController(BaseController):
                             'filters':{'search':search_str}}
                }
 
+    @expose('mako:fedoracommunity.templates.opensearch', content_type='text/xml')
+    def opensearch(self, *args, **kwds):
+        '''OpenSearch provider'''
+        if len(args) > 0 and args[0] == 'fedora_packages.xml':
+            return {'title': 'Fedora Packages'}
+        else:
+            redirect('/')
+
     @expose('mako:fedoracommunity.widgets.templates.widget_loader')
     def _w(self, widget_name, *args, **kwds):
         '''generic widget controller - loads a widget from our widget list

--- a/fedoracommunity/templates/chrome.mak
+++ b/fedoracommunity/templates/chrome.mak
@@ -16,6 +16,9 @@
       type="image/vnd.microsoft.icon" rel="shortcut icon" />
     <link href="//fedoraproject.org/favicon.ico"
       type="image/x-icon" rel="shortcut icon"/>
+    <link title="${title}"
+      rel="search" type="application/opensearchdescription+xml"
+      href="${tg.url('/opensearch')}/fedora_packages.xml" />
 
     <!--[if lt IE 7]>
     <style type="text/css">

--- a/fedoracommunity/templates/opensearch.mak
+++ b/fedoracommunity/templates/opensearch.mak
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>${title}</ShortName>
+  <Description>Search ${title}</Description>
+  <Tags>${title}</Tags>
+  <Url type="text/html"
+      template="${request.host_url}${tg.url('/s')}/{searchTerms}"/>
+  <Url type="application/opensearchdescription+xml"
+      template="${request.host_url}${tg.url('/opensearch')}/fedora_packages.xml"/>
+  <SearchForm>${request.host_url}${tg.url('/s')}</SearchForm>
+</OpenSearchDescription>

--- a/fedoracommunity/templates/search.mak
+++ b/fedoracommunity/templates/search.mak
@@ -15,6 +15,9 @@
       type="image/vnd.microsoft.icon" rel="shortcut icon" />
     <link href="//fedoraproject.org/favicon.ico"
       type="image/x-icon" rel="shortcut icon"/>
+    <link title="${title}"
+      rel="search" type="application/opensearchdescription+xml"
+      href="${tg.url('/opensearch')}/fedora_packages.xml" />
 
     <!--[if lt IE 7]>
     <style type="text/css">


### PR DESCRIPTION
* Add a new endpoint /packages/opensearch that serves fedora_packages.xml
* Add a new opensearch template
* Add opensearch description link to chrome and search templates so the
  provider is visible in these two pages.

Fixes: #144 #422 